### PR TITLE
Use GetSizeUsingAttributes instead of deprecated StringSize

### DIFF
--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -999,8 +999,8 @@ namespace BigTed
 
 			if (!string.IsNullOrEmpty (@string))
 			{
-				int lineCount = Math.Min (10, @string.Split ('\n').Length + 1);
-				var stringSize = new NSString (@string).StringSize (StringLabel.Font, new CGSize (200, 30 * lineCount));
+                int lineCount = Math.Min (10, @string.Split ('\n').Length + 1);
+                var stringSize = new NSString (@string).GetSizeUsingAttributes (new UIStringAttributes{Font = StringLabel.Font});
 				stringWidth = stringSize.Width;
 				stringHeight = stringSize.Height;
 


### PR DESCRIPTION
BTProgressHUD failed in IOS 8 for latest Xamarin.iOS unified, with a MissingMethod exception for StringSize, which is deprecated in IOS 7. By using GetSizeUsingAttributes instead, it works.