### PR TITLE
check if window IsKeyWindow when trying to add the overlayview

### DIFF
--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -274,7 +274,7 @@ namespace BigTed
 				var windows = UIApplication.SharedApplication.Windows;
 				Array.Reverse (windows);
 				foreach (UIWindow window in windows) {
-					if (window.WindowLevel == UIWindowLevel.Normal && !window.Hidden) {
+                    if (window.WindowLevel == UIWindowLevel.Normal && !window.Hidden && window.IsKeyWindow) {
 						window.AddSubview (OverlayView);
 						break;
 					}


### PR DESCRIPTION
check if window IsKeyWindow when trying to add the overlayview to fix this issue:
https://github.com/nicwise/BTProgressHUD/issues/52
